### PR TITLE
Allow mdx file extension

### DIFF
--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -100,7 +100,9 @@ export default class TreeProvider implements TreeDataProvider<ResultsTreeItem> {
     }
 
     private analyze() {
-        if(!window.activeTextEditor?.document.fileName.endsWith("md")) {
+        const fileNameSplit = window.activeTextEditor?.document.fileName.split('.');
+        const fileExtension = fileNameSplit?.[fileNameSplit.length - 1];
+        if(fileExtension && !['md', 'mdx'].includes(fileExtension)) {
             window.showErrorMessage("Better SEO: Current file is not a Markdown file");
             return;
         }


### PR DESCRIPTION
First off cool plugin!

I installed it and noticed that it does not work for me because I use `.mdx` as file extension. I just changed 3 lines to also make your plugin work with it. 

I quickly tested it and it seems to work well.

MDX is a popular Markdown extension which allows JSX: https://mdxjs.com/
So it's mostly normal MD and the different file extension states that I'm sure what I am doing with all the  JSX 😄 .