### PR TITLE
Fix keyword error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.8.2
+
+- Fixes an issue where analysis would silently fail if `Keywords:` within Frontmatter was empty.
+
 ## 1.8.1
 
 - Updates the change log file with all previous release information

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "type": "git",
         "url": "https://github.com/schultyy/better-seo"
     },
-    "version": "1.8.1",
+    "version": "1.8.2",
     "icon": "resources/better_seo.png",
     "engines": {
         "vscode": "^1.55.0"

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -65,6 +65,9 @@ export function extractKeywords(currentFile: string) :Array<string> {
 }
 
 function doesKeywordPartialMatch(keyword: string, fieldValue: string) : boolean {
+    if(!keyword) {
+        return false;
+    }
     const splittedKeyword = keyword.split(' ');
     const foundWordResults = [];
 
@@ -156,7 +159,7 @@ export class FileAnalyzer {
         if(!header) {
             analyzerResults.push(new AnalyzerError('Article Title', 'Not found', ResultType.body));
         }
-        if(header && header.raw.indexOf(keywords[0]) === -1) {
+        if(header &&keywords[0] && header.raw.indexOf(keywords[0]) === -1) {
             if(!doesKeywordPartialMatch(keywords[0], header.raw)) {
                 analyzerResults.push(new AnalyzerError('Article Title', `Keyword ${keywords[0]} not found`, ResultType.body));
             }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -84,6 +84,24 @@ seo_description: Learn how to seo perfectly in your business
 Lorem Ipsum Dolor Sit Amet`;
 
 
+const emptyKeywords = `---
+Keywords:
+seo_title: This is about seo
+seo_description: Learn how to seo perfectly
+---
+# Foo
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Enim tortor at auctor urna nunc id. Nibh sed pulvinar proin gravida hendrerit. Dolor magna eget est lorem ipsum dolor sit amet. Massa id neque aliquam vestibulum morbi blandit cursus. Dolor magna eget est lorem. Dolor purus non enim praesent elementum facilisis leo vel fringilla. Facilisis volutpat est velit egestas. Eget egestas purus viverra accumsan in nisl. Pellentesque nec nam aliquam sem. Enim praesent elementum facilisis leo vel fringilla est. Est ullamcorper eget nulla facilisi etiam dignissim diam quis enim. Venenatis lectus magna fringilla urna porttitor rhoncus dolor purus. Faucibus ornare suspendisse sed nisi lacus. Leo vel orci porta non pulvinar neque laoreet suspendisse interdum. Placerat vestibulum lectus mauris ultrices eros. Facilisis volutpat est velit egestas dui id ornare arcu odio. Tortor condimentum lacinia quis vel eros donec ac.
+
+Consectetur a erat nam at lectus. Vivamus at augue eget arcu dictum varius. Malesuada proin libero nunc consequat interdum varius. Placerat vestibulum lectus mauris ultrices eros in cursus. Lacus sed turpis tincidunt id aliquet risus feugiat in. At quis risus sed vulputate odio ut. Semper feugiat nibh sed pulvinar proin gravida hendrerit lectus a. Aliquam sem fringilla ut morbi tincidunt augue interdum velit. Diam ut venenatis tellus in metus vulputate eu. Nisi lacus sed viverra tellus. Parturient montes nascetur ridiculus mus mauris vitae ultricies leo integer. Massa id neque aliquam vestibulum morbi blandit cursus risus at. Amet justo donec enim diam vulputate ut pharetra sit. Vel fringilla est ullamcorper eget nulla facilisi etiam dignissim diam. Amet massa vitae tortor condimentum lacinia quis vel eros. Sit amet nulla facilisi morbi tempus. Tortor vitae purus faucibus ornare suspendisse sed. Arcu cursus vitae congue mauris rhoncus aenean. Tempus iaculis urna id volutpat lacus laoreet non curabitur gravida. Ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit.
+
+Habitant morbi tristique senectus et netus et. Quis eleifend quam adipiscing vitae proin sagittis. Porta non pulvinar neque laoreet. Egestas pretium aenean pharetra magna ac placerat vestibulum lectus mauris. Pulvinar mattis nunc sed blandit libero volutpat sed. Interdum varius sit amet mattis vulputate enim. Praesent tristique magna sit amet purus gravida quis blandit turpis. Fermentum odio eu feugiat pretium. Egestas congue quisque egestas diam in arcu. Metus aliquam eleifend mi in. Vivamus arcu felis bibendum ut tristique et. Aliquam ultrices sagittis orci a. At in tellus integer feugiat. Vulputate sapien nec sagittis aliquam malesuada bibendum arcu vitae elementum. Vestibulum morbi blandit cursus risus at ultrices mi tempus imperdiet. Urna porttitor rhoncus dolor purus non. Ut diam quam nulla porttitor. Dolor sit amet consectetur adipiscing elit pellentesque habitant. Sed viverra tellus in hac.
+
+Ut faucibus pulvinar elementum integer enim. Sit amet volutpat consequat mauris nunc congue nisi. Cursus mattis molestie a iaculis at erat pellentesque adipiscing. Pulvinar etiam non quam lacus suspendisse. Libero justo laoreet sit amet cursus sit. Vivamus at augue eget arcu dictum varius. Vestibulum lorem sed risus ultricies tristique nulla. Vel fringilla est ullamcorper eget nulla. Purus sit amet volutpat consequat mauris nunc congue nisi. In hendrerit gravida rutrum quisque non. Vel pretium lectus quam id. Suscipit adipiscing bibendum est ultricies integer. Morbi tempus iaculis urna id volutpat lacus laoreet non curabitur. Consectetur a erat nam at lectus urna duis convallis convallis.
+
+Enim lobortis scelerisque fermentum dui faucibus in ornare. Eget gravida cum sociis natoque. Enim ut sem viverra aliquet eget. Mattis rhoncus urna neque viverra justo nec ultrices dui sapien. Eget nunc scelerisque viverra mauris in aliquam sem. Risus at ultrices mi tempus imperdiet nulla malesuada pellentesque elit. Auctor augue mauris augue neque gravida in fermentum et. Aliquet bibendum enim facilisis gravida. In hac habitasse platea dictumst vestibulum rhoncus. Nibh nisl condimentum id venenatis a condimentum vitae sapien pellentesque.
+`;
+
 const noKeywords = `---
 seo_title: This is about seo
 seo_description: Learn how to seo perfectly
@@ -232,6 +250,11 @@ suite('Extension Test Suite', () => {
 
         test('returns empty list if no keywords are found', () => {
             const keywords = extractKeywords(noKeywords);
+            assert.notStrictEqual([], keywords);
+        });
+
+        test('returns empty list if frontmatter keywords list is empty', () => {
+            const keywords = extractKeywords(emptyKeywords);
             assert.notStrictEqual([], keywords);
         });
     });
@@ -387,6 +410,17 @@ suite('Extension Test Suite', () => {
                 );
 
                 assert.strictEqual(validationResult.length, 0);
+            });
+        });
+
+        describe('With Empty Keyword List', () => {
+            test('does not add keyword-related validation errors', () => {
+                /*
+                    Sometimes, we might want to write a blog post where we haven't performed any keyword
+                    research and in those cases we don't want any complaints about missing keywords in article
+                */
+                const results = runAnalysis(emptyKeywords, frontmatterConfiguration);
+                assert.strictEqual(results.length, 0);
             });
         });
     });

--- a/src/treeProvider.ts
+++ b/src/treeProvider.ts
@@ -44,7 +44,7 @@ export default class TreeProvider implements TreeDataProvider<ResultsTreeItem> {
         else if(element.label === 'Header') {
             return Promise.resolve(
                 this.generateHeaderErrors(<HeaderFinding> element)
-            )
+            );
         }
         else {
             return Promise.resolve([]);


### PR DESCRIPTION
This PR fixes an issue where Analysis would silently fail when a user would have a frontmatter like this in their blog post:

```yaml
---
Keywords:
---
```
Previously, we already handled cases where no `Keywords` key was present but we didn't handle the case when it was `undefined` or an empty list.
